### PR TITLE
fix: npm package vulnerabilities (tmp, d3-color)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
   },
   "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a",
   "pnpm": {
+    "overrides": {
+      "tmp": ">=0.2.4",
+      "d3-color": ">=3.1.0"
+    },
     "patchedDependencies": {
       "next@14.2.30": "patches/next@14.2.30.patch"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tmp: '>=0.2.4'
+  d3-color: '>=3.1.0'
+
 patchedDependencies:
   next@14.2.30:
     hash: o4ig42vhz3o44qe52754g7f5ea
@@ -3500,10 +3504,6 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -4110,9 +4110,9 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -8285,8 +8285,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  os-tmpdir@1.0.2: {}
-
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -8357,7 +8355,7 @@ snapshots:
       rimraf: 2.7.1
       semver: 7.7.2
       slash: 2.0.0
-      tmp: 0.0.33
+      tmp: 0.2.5
       yaml: 2.8.0
 
   path-exists@4.0.0: {}
@@ -8962,9 +8960,7 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tmp@0.2.5: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
This pull request addresses two security vulnerabilities identified by `pnpm audit` in the project's dependencies. By using `pnpm`'s `overrides` feature, we can enforce the use of secure package versions without waiting for upstream maintainers to update their dependencies.

**Key Changes:**

*   **Resolved High-Severity `d3-color` Vulnerability**:
    *   A high-severity vulnerability was found in `d3-color`, a sub-dependency of `recharts`.
    *   Added an override in package.json to force the resolution of `d3-color` to version `>=3.1.0`, which contains the necessary security patch.

*   **Resolved Low-Severity `tmp` Vulnerability**:
    *   A low-severity vulnerability was identified in the `tmp` package, a sub-dependency of `patch-package`.
    *   Added an override for `tmp` to ensure it resolves to version `>=0.2.4`, which mitigates the issue.

**How to Verify:**

1.  Check out this branch.
2.  Run `pnpm install` to apply the new overrides.
3.  Run `pnpm audit` in your terminal.
4.  Confirm that the command completes successfully and reports "No known vulnerabilities found."